### PR TITLE
Movie unwatched refined & smarter movie scraping

### DIFF
--- a/plexdl.py
+++ b/plexdl.py
@@ -148,11 +148,12 @@ debug_outputxml = False     #output relevant XML when exceptions occur
 debug_pretenddld = False     #set to true to fake downloading.  connects to Plex but doesn't save the file.
 debug_pretendremove = False    #set to true to fake removing files
 debug_plexurl = False        #set to true to output plex URL  (caution - will output Plex token)
+minimum_to_watch_else_considerd_unwatched = 0.90        #minimum % to have watched an episode otherwise will be marked as unwatched todo: configurable
 verbose = 0
 
 plextoken=""
 
-print "PlexDownloader - v0.07"
+print "PlexDownloader - v0.08"
 
 class MovieDownloader(object):
     class NoConfig(Exception):
@@ -203,6 +204,8 @@ class MovieDownloader(object):
             #title = re.sub(r'[^\x00-\x7F]+',' ', title)
             title = re.sub(r'\&','and', title)
             title = title.strip()
+            duration = long(geta(item,'duration'))
+            this_minimum_to_watch = long(duration * minimum_to_watch_else_considerd_unwatched)
             itemkey = geta(item, 'key')
             try:
                 year = geta(item, 'year')
@@ -210,19 +213,32 @@ class MovieDownloader(object):
                 year="Unknown"
             try:
                 #checks to see if view count node is available
-                viewcount = geta(item, 'viewCount')
+                viewcount = long(geta(item, 'lastViewedAt'))
             except Exception as e:
                 #if fails to find viewCount will notify script that it can continue
                 viewcount = "unwatched"
+            try:
+                viewOffset = long(geta(item, 'viewOffset'))
+                if viewOffset < this_minimum_to_watch: viewcount = "partial"
+                if viewOffset >= this_minimum_to_watch: viewcount = "overpartial"
+            except Exception as e:
+                #if fails to find viewOffset will notify script that tv is unwatched
+                viewOffset = 0
+
             #checks if user wants unwatched only
-            if self.unwatched=="enable":
-                if viewcount=="unwatched":
-                    if verbose: print title + " ("+year+") is unwatched..."
-                else:
-                    if verbose: print title + " ("+year+") is watched... skipping!"
-                    continue
             itemname = title + " ("+year+")"
             if (itemname in wantedlist) or (self.sync=="enable"):
+                if self.unwatched=="enable":
+                    if viewcount=="unwatched" or viewcount=="" :
+                        print "Movie: " + itemname + " is found in Wanted List and unwatched..." 
+                    elif viewcount=="partial":
+                        print ( "Movie: " + itemname + " is {:.0%} < {:.0%} watched... INCLUDING ! ").format(float(viewOffset)/float(duration),minimum_to_watch_else_considerd_unwatched)
+                    elif viewcount=="overpartial":
+                        print ( "Movie: " + itemname + " is {:.0%} > {:.0%} watched... skipping ! ").format(float(viewOffset)/float(duration),minimum_to_watch_else_considerd_unwatched)
+                        continue
+                    else:
+                        print "Movie: " + itemname + " is found in Wanted List yet watched ... skipping! "
+                        continue
                 try:
                     parts = getMediaContainerParts(itemkey)
                     if parts:
@@ -231,13 +247,20 @@ class MovieDownloader(object):
                         if parts:
                             self.download(itemname,itemkey,parts)
                             syncedItems += 1
+                        else:
+                            print "Movie: " + itemname + " already synced, nothing to do"
+                            if verbose: 
+                                print "Movie: " + itemname + " already synced, nothing to do"
+                            else:
+                                True
+
                 except Exception as e:
                     failedItems += 1
                     print "Error syncing " + itemname + ".  Skipping..."
                     print(traceback.format_exc())
                     if debug_outputxml: print item.toprettyxml(encoding='utf-8')
             else:
-                if verbose: print itemname + " Not Found in Wanted List."
+                if verbose: True #print itemname + " Not Found in Wanted List."
         if syncedItems > 0 or failedItems > 0:
             print "Movie sync complete: %d downloaded  %d errors" % (syncedItems, failedItems)
 
@@ -379,7 +402,7 @@ class TvDownloader(object):
                     numEpisodes = 2  #number of episodes to retain.  todo: make this configurable
                     #shrink to just last N episodes.
                     episodelist = sorted(episodelist, key = lambda x: (int(geta(x,'seasonIndex')), int(geta(x,'index'))))[0-numEpisodes:]
-                if verbose: print "Syncing %d episodes for %s" %(len(episodelist), title)
+                if verbose: print "    Syncing %d episodes for %s" %(len(episodelist), title)
                 for counter, episode in enumerate(episodelist):
                     try:
                         episodekey = geta(episode, u'key')
@@ -387,18 +410,35 @@ class TvDownloader(object):
                         episodetitle = geta(episode, u'title')
                         episodetitle = episodetitle.strip()
                         seasonindex = geta(episode, 'seasonIndex')  #Added during list creation
+                        duration = long(geta(episode, 'duration'))
+                        this_minimum_to_watch = long(duration * minimum_to_watch_else_considerd_unwatched)
+                        if verbose: print ("Analyzing Episode S{0}E{1}").format(seasonindex, episodeindex)
+                        ## if debug_outputxml: print episode.toprettyxml()
+                        ## if verbose: print "    Duration " + str(duration)
+                        ## if verbose: print "    Minimum to watch " + str(this_minimum_to_watch)
                         try:
                             #checks to see if episode has been viewed node is available
-                            viewcount = geta(episode, 'lastViewedAt')
+                            viewcount = long(geta(episode, 'lastViewedAt'))
                         except Exception as e:
                             #if fails to find lastViewedAt will notify script that tv is unwatched
                             viewcount = "unwatched"
+                        try:
+                            viewOffset = long(geta(episode, 'viewOffset'))
+                            if viewOffset < this_minimum_to_watch: viewcount = "partial"
+                        except Exception as e:
+                            #if fails to find viewOffset will notify script that tv is unwatched
+                            viewOffset = 0
+                        ## if verbose: print "    viewOffset " + str(viewOffset)
+                        ## if verbose: print "    viewcount: " + str(viewcount)
                         #checks if user wants unwatched only
                         if self.unwatched=="enable":
                             if viewcount=="unwatched":
-                                if verbose: print "Episode is unwatched..."
+                                if verbose: print "    Episode is unwatched..."
+                            elif viewcount=="partial":
+                                if verbose: print ("    Episode is {:.0%} < {:.0%} watched... INCLUDING ! ").format(float(viewOffset)/float(duration),minimum_to_watch_else_considerd_unwatched)
                             else:
-                                if verbose: print "Episode is watched... skipping!"
+                                if verbose: print "    Episode is watched... skipping!"
+                                #todo: remove files that are watched when tvtype = all
                                 continue
                         parts = getMediaContainerParts(episodekey)
                         if parts:
@@ -407,9 +447,11 @@ class TvDownloader(object):
                             if parts:
                                 self.download(title,seasonindex,episodeindex,episodetitle,episodekey,parts)
                                 syncedItems += 1
+                            else:
+                                if verbose: print "    Episode is already synced ..."
                     except Exception as e:
                         failedItems += 1
-                        print "Error syncing episode.  Skipping..."
+                        print "    Error syncing episode.  Skipping..."
                         print(traceback.format_exc())
                         if debug_outputxml: print episode.toprettyxml(encoding='utf-8')
                 #remove old episodes

--- a/scrape.py
+++ b/scrape.py
@@ -93,160 +93,210 @@ tvscrapetype = parser.get('scrape', 'tvsearch')
 tvscrapelimit = int(parser.get('scrape', 'tvlimit'))
 scrapetimer = int(parser.get('scrape', 'timer'))
 
+debug_limitdld = False      #set to true during development to limit size of downloaded files
+debug_outputxml = False     #output relevant XML when exceptions occur
+debug_pretenddld = False     #set to true to fake downloading.  connects to Plex but doesn't save the file.
+debug_pretendremove = False    #set to true to fake removing files
+debug_plexurl = False        #set to true to output plex URL  (caution - will output Plex token)
+minimum_to_watch_else_considerd_unwatched = 0.95        #minimum % to have watched an episode otherwise will be marked as unwatched todo: configurable
+verbose = 0
 
 plexsession=str(uuid.uuid4())
 socket.setdefaulttimeout(180)
 
 plextoken=""
 
-print "PlexScraper - v0.01"
+print "PlexScraper - v0.02"
 
 def tvShowScraper(searchtype):
-	x=0
-	tvopen = open(tvfile,"r")
-	tvread = tvopen.read()
-	tvlist= tvread.split("\n")
-	tvopen.close()
-	print str(len(tvlist)-1) + " TV Shows Found in Your Wanted List..."
-	if myplexstatus=="enable":
-		tvhttp=url+"/library/sections/"+tvshowid+"/"+searchtype+"?X-Plex-Token="+plextoken
-	else:
-		tvhttp=url+"/library/sections/"+tvshowid+"/"+searchtype
-	website = urllib.urlopen(tvhttp)
-	xmldoc = minidom.parse(website)
-	itemlist = xmldoc.getElementsByTagName('Directory')
-	print str(len(itemlist)) + " Total TV Shows Found"
-	for item in itemlist:
-		tvkey = item.attributes['key'].value
-		tvtitle = item.attributes['title'].value
-		#tvtitle = re.sub(r'[^\x00-\x7F]+',' ', tvtitle)
-		tvtitle = re.sub(r'\&','and', tvtitle)
-		if (x <= tvscrapelimit):
-			tvlist.append(tvtitle)
-		x=x+1
-	tvlist = list(set(tvlist))
-	tvopen = open(tvfile,"r")
-	tvread = tvopen.read()
-	while '' in tvlist:
-		tvlist.remove('')
-	tvopen.close()
-	tvopen = open(tvfile,"w+")
-	for item in tvlist:
-		tvwrite = tvopen.write(item+"\n")
-	tvopen.close()
+    x=0
+    tvopen = open(tvfile,"r")
+    tvread = tvopen.read()
+    tvlist= tvread.split("\n")
+    tvopen.close()
+    print str(len(tvlist)-1) + " TV Shows Found in Your Wanted List..."
+    if myplexstatus=="enable":
+        tvhttp=url+"/library/sections/"+tvshowid+"/"+searchtype+"?X-Plex-Token="+plextoken
+    else:
+        tvhttp=url+"/library/sections/"+tvshowid+"/"+searchtype
+    website = urllib.urlopen(tvhttp)
+    xmldoc = minidom.parse(website)
+    itemlist = xmldoc.getElementsByTagName('Directory')
+    print str(len(itemlist)) + " Total TV Shows Found"
+    for item in itemlist:
+        tvkey = item.attributes['key'].value
+        tvtitle = item.attributes['title'].value
+        #tvtitle = re.sub(r'[^\x00-\x7F]+',' ', tvtitle)
+        tvtitle = re.sub(r'\&','and', tvtitle)
+        if (x <= tvscrapelimit):
+            tvlist.append(tvtitle)
+        x=x+1
+    tvlist = list(set(tvlist))
+    tvopen = open(tvfile,"r")
+    tvread = tvopen.read()
+    while '' in tvlist:
+        tvlist.remove('')
+    tvopen.close()
+    tvopen = open(tvfile,"w+")
+    for item in tvlist:
+        tvwrite = tvopen.write(item+"\n")
+    tvopen.close()
 
 
 
 def movieScraper(searchtype):
-	x=0
-	movieopen = open(moviefile,"r")
-	movieread = movieopen.read()
-	movielist= movieread.split("\n")
-	movieopen.close()
-	print str(len(movielist)-1) + " Movies Found in Your Wanted List..."
+    movieopen = open(moviefile,"r")
+    movieread = movieopen.read()
+    movielist= movieread.split("\n")
+    movieopen.close()
+    moviealreadyinlist = len(movielist)-1
+    print str(moviealreadyinlist) + " Movies Found in Your Wanted List..."
+    if myplexstatus=="enable":
+        moviehttp=url+"/library/sections/"+movieid+"/all?X-Plex-Token="+plextoken
+    else:
+        moviehttp=url+"/library/sections/"+movieid+"/all"
 
-	if myplexstatus=="enable":
-		moviehttp=url+"/library/sections/"+movieid+"/"+searchtype+"?X-Plex-Token="+plextoken
-	else:
-		moviehttp=url+"/library/sections/"+movieid+"/"+searchtype
-	website = urllib.urlopen(moviehttp)
-	xmldoc = minidom.parse(website)
-	itemlist = xmldoc.getElementsByTagName('Video')
-	print str(len(itemlist)) + " Total Movies Found"
-	for item in itemlist:
-		movietitle = item.attributes['title'].value
-		#movietitle = re.sub(r'[^\x00-\x7F]+',' ', movietitle)
-		movietitle = re.sub(r'\&','and', movietitle)
-		moviedata = item.attributes['key'].value
-		movieratingkey = item.attributes['ratingKey'].value
-		try:
-			movieyear = item.attributes['year'].value
-		except:
-			movieyear="Unknown"
-		moviename = movietitle + " ("+movieyear+")"
-		if (x <= moviescrapelimit):
-			movielist.append(moviename)
-		x=x+1
-	movielist = list(set(movielist))
-	movieopen = open(moviefile,"r")
-	movieread = movieopen.read()
-	while '' in movielist:
-		movielist.remove('')
-	movieopen.close()
-	movieopen = open(moviefile,"w+")
-	for item in movielist:
-		moviewrite = movieopen.write(item+"\n")
-	movieopen.close()
+    
+    website = urllib.urlopen(moviehttp)
+    xmldoc = minidom.parse(website)
+    itemlist = xmldoc.getElementsByTagName('Video')
+    found_movies = len(itemlist)
+    print str(found_movies) + " Total Movies Found"
+    if verbose: print "ini moviescrapelimit " + str(moviescrapelimit)
+    movietoscrape = moviescrapelimit
+    movietoscrape = moviescrapelimit - moviealreadyinlist
+    print "Found " + str(moviescrapelimit) + " movies in your wanted list and moviescraping is set to maximum " + str(moviescrapelimit) + ", movies to add by scraper " + str(movietoscrape)
+    random_movie = 0 
+    x=1
+
+    while x <= movietoscrape:
+        random_movie = random.randrange(0, found_movies, 1)
+        item = itemlist[random_movie]
+        if verbose: print "Choose random movie:" + (item.attributes['title'].value) # + "\n" +  item.toprettyxml()
+        duration = long(item.attributes['duration'].value)
+        this_minimum_to_watch = long(duration * minimum_to_watch_else_considerd_unwatched)
+        try:
+            #checks to see if episode has been viewed node is available
+            viewcount = long(itemlist[random_movie].attributes['lastViewedAt'].value)
+        except Exception as e:
+            #if fails to find lastViewedAt will notify script that tv is unwatched
+            viewcount = "unwatched"
+
+        try:
+            viewOffset = long(itemlist[random_movie].attributes['viewOffset'].value)
+            if verbose: print "    viewOffset: " + str(viewOffset)
+            if viewOffset < this_minimum_to_watch: viewcount = "partial"
+            #if viewOffset < (duration - 316482) : viewcount = "partial - 5 min"
+        except Exception as e:
+            #if fails to find viewOffset will notify script that tv is unwatched
+            viewOffset = 0
+        if verbose: print "    viewcount: " + str(viewcount)
+        if verbose: print "    x: " + str(x)
+        
+        movietitle = item.attributes['title'].value
+        #movietitle = re.sub(r'[^\x00-\x7F]+',' ', movietitle)
+        movietitle = re.sub(r'\&','and', movietitle)
+        moviedata = item.attributes['key'].value
+        movieratingkey = item.attributes['ratingKey'].value
+        # print (movietitle)
+        try:
+            movieyear = item.attributes['year'].value
+        except:
+            movieyear="Unknown"
+        moviename = movietitle + " ("+movieyear+")"
+        # random_movie = random_movie + 1 # only here for testing purpose
+        if debug_outputxml: print item.toprettyxml(encoding='utf-8')
+        if movieunwatched !="enable" or (movieunwatched=="enable" and (str(viewcount)=='partial' or str(viewcount)=='unwatched')):
+            ## when setting 'movieunwatched' is found only add unwatched or partially watched movies, otherwise add anyway
+            print "Adding: " + viewcount + " movie: "+ moviename + "\n"
+            movielist.append(moviename)
+            x=x+1
+        else:
+            print "Skipping: watched movie " + moviename + "\n"
+        
+        ## only touch the movie file when changed by the scraper
+        if x>0:
+            ## todo: update web page when movie is added
+            movielist = list(set(movielist))
+            movieopen = open(moviefile,"r")
+            movieread = movieopen.read()
+            while '' in movielist:
+                movielist.remove('')
+            movieopen.close()
+            movieopen = open(moviefile,"w+")
+            for item in movielist:
+                moviewrite = movieopen.write(item+"\n")
+            movieopen.close()
 
 
 def photoScraper(searchtype):
-	pictureopen = open(picturefile,"r")
-	pictureread = pictureopen.read()
-	picturelist= pictureread.split("\n")
-	pictureopen.close()
-	print str(len(picturelist)-1) + " Albums Found in Your Wanted List..."
+    pictureopen = open(picturefile,"r")
+    pictureread = pictureopen.read()
+    picturelist= pictureread.split("\n")
+    pictureopen.close()
+    print str(len(picturelist)-1) + " Albums Found in Your Wanted List..."
 
-	if myplexstatus=="enable":
-		pichttp=url+"/library/sections/"+pictureid+"/"+searchtype+"?X-Plex-Token="+plextoken
-	else:
-		pichttp=url+"/library/sections/"+pictureid+"/"+searchtype
-	website = urllib.urlopen(pichttp)
-	xmldoc = minidom.parse(website)
-	itemlist = xmldoc.getElementsByTagName('Directory')
-	print str(len(itemlist)) + " Total Albums Found"
-	for item in itemlist:
-		albumtitle = item.attributes['title'].value
-		#albumtitle = re.sub(r'[^\x00-\x7F]+',' ', albumtitle)
-		albumtitle = re.sub(r'\&','and', albumtitle)
-		albumkey = item.attributes['key'].value
+    if myplexstatus=="enable":
+        pichttp=url+"/library/sections/"+pictureid+"/"+searchtype+"?X-Plex-Token="+plextoken
+    else:
+        pichttp=url+"/library/sections/"+pictureid+"/"+searchtype
+    website = urllib.urlopen(pichttp)
+    xmldoc = minidom.parse(website)
+    itemlist = xmldoc.getElementsByTagName('Directory')
+    print str(len(itemlist)) + " Total Albums Found"
+    for item in itemlist:
+        albumtitle = item.attributes['title'].value
+        #albumtitle = re.sub(r'[^\x00-\x7F]+',' ', albumtitle)
+        albumtitle = re.sub(r'\&','and', albumtitle)
+        albumkey = item.attributes['key'].value
 
 
 
 
 def musicScraper(searchtype):
-	musicopen = open(musicfile,"r")
-	musicread = musicopen.read()
-	musiclist= musicread.split("\n")
-	musicopen.close()
-	print str(len(musiclist)-1) + " Artists Found in Your Wanted List..."
-	if myplexstatus=="enable":
-		musichttp=url+"/library/sections/"+musicid+"/"+searchtype+"?X-Plex-Token="+plextoken
-	else:
-		musichttp=url+"/library/sections/"+musicid+"/"+searchtype
-	website = urllib.urlopen(musichttp)
-	xmldoc = minidom.parse(website)
-	#Get list of artists
-	itemlist = xmldoc.getElementsByTagName('Directory')
-	print str(len(itemlist)) + " Total Artists Found"
-	for item in itemlist:
-		musictitle = item.attributes['title'].value
-		#musictitle = re.sub(r'[^\x00-\x7F]+',' ', musictitle)
-		musictitle = re.sub(r'\&','and', musictitle)
-		musickey = item.attributes['key'].value
+    musicopen = open(musicfile,"r")
+    musicread = musicopen.read()
+    musiclist= musicread.split("\n")
+    musicopen.close()
+    print str(len(musiclist)-1) + " Artists Found in Your Wanted List..."
+    if myplexstatus=="enable":
+        musichttp=url+"/library/sections/"+musicid+"/"+searchtype+"?X-Plex-Token="+plextoken
+    else:
+        musichttp=url+"/library/sections/"+musicid+"/"+searchtype
+    website = urllib.urlopen(musichttp)
+    xmldoc = minidom.parse(website)
+    #Get list of artists
+    itemlist = xmldoc.getElementsByTagName('Directory')
+    print str(len(itemlist)) + " Total Artists Found"
+    for item in itemlist:
+        musictitle = item.attributes['title'].value
+        #musictitle = re.sub(r'[^\x00-\x7F]+',' ', musictitle)
+        musictitle = re.sub(r'\&','and', musictitle)
+        musickey = item.attributes['key'].value
 
 
 
 while True:
-	try:
-		if myplexstatus=="enable":
-			plextoken = myPlexSignin(myplexusername,myplexpassword)
-		if myplexstatus=="enable" and plextoken=="":
-			print "Failed to login to myPlex. Please disable myPlex or enter your correct login."
-			exit()
-		if tvactive=="enable" and tvscrapetype != "disable":
-			tvShowScraper(tvscrapetype)
-		if movieactive=="enable" and moviescrapetype != "disable":
-			movieScraper(moviescrapetype)
-		#if pictureactive=="enable":
-		#	photoScraper('recentlyAdded')
-		#if musicactive=="enable":
-		#	musicScraper('recentlyAdded')
+    try:
+        if myplexstatus=="enable":
+            plextoken = myPlexSignin(myplexusername,myplexpassword)
+        if myplexstatus=="enable" and plextoken=="":
+            print "Failed to login to myPlex. Please disable myPlex or enter your correct login."
+            exit()
+        if tvactive=="enable" and tvscrapetype != "disable":
+            tvShowScraper(tvscrapetype)
+        if movieactive=="enable" and moviescrapetype != "disable":
+            movieScraper("")
+        #if pictureactive=="enable":
+        #    photoScraper('recentlyAdded')
+        #if musicactive=="enable":
+        #    musicScraper('recentlyAdded')
 
-		print "Plex Scraper completed at "+ strftime("%Y-%m-%d %H:%M:%S")
-		print "Sleeping "+str(scrapetimer)+" Seconds..."
-		time.sleep(scrapetimer)
-	except Exception,e:
-		print "Something went wrong: " + str(e)
-		print "Plex Scraper failed at "+ strftime("%Y-%m-%d %H:%M:%S")
-		print "Retrying in "+str(scrapetimer)+" Seconds..."
-		time.sleep(scrapetimer)
+        print "Plex Scraper completed at "+ strftime("%Y-%m-%d %H:%M:%S")
+        print "Plex Scraper Sleeping "+str(scrapetimer)+" Seconds..."
+        time.sleep(scrapetimer)
+    except Exception,e:
+        print "Something went wrong: " + str(e)
+        print "Plex Scraper failed at "+ strftime("%Y-%m-%d %H:%M:%S")
+        print "Retrying in "+str(scrapetimer)+" Seconds..."
+        time.sleep(scrapetimer)


### PR DESCRIPTION
plexdl:
- now partial watched movies will be synced
  scrape:
- don't add more to movies.txt than set in scrape-setting
- skip updating movies.txt when nothing scraped
- choose random movie instead of ordered list: kinda boring
- don't add (partial) watched movies to movies.txt when
  movies:unwatched=enable is set (otherwise won't be synced by plexdl
  anyway)
  todo: update webpage when scrape modified movies.txt
  todo: ?remove watched movie from movies.txt while scraping?

IMHO I don't think that TV-scraping is usefull, don't want to add
"random" tv-episodes
